### PR TITLE
Add container run --security-opt systempaths=unconfined

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -183,6 +183,7 @@ func setCreateFlags(cmd *cobra.Command) {
 			"seccomp=", "seccomp=" + defaults.SeccompProfileName, "seccomp=unconfined",
 			"apparmor=", "apparmor=" + defaults.AppArmorProfileName, "apparmor=unconfined",
 			"no-new-privileges",
+			"systempaths=unconfined",
 			"privileged-without-host-devices"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	// cap-add and cap-drop are defined as StringSlice, not StringArray, to allow specifying "--cap-add=CAP_SYS_ADMIN,CAP_NET_ADMIN" (compatible with Podman)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -230,6 +230,7 @@ Security flags:
 - :whale: `--security-opt seccomp=<PROFILE_JSON_FILE>`: specify custom seccomp profile
 - :whale: `--security-opt apparmor=<PROFILE>`: specify custom AppArmor profile
 - :whale: `--security-opt no-new-privileges`: disallow privilege escalation, e.g., setuid and file capabilities
+- :whale: `--security-opt systempaths=unconfined`: Turn off confinement for system paths (masked paths, read-only paths) for the container
 - :nerd_face: `--security-opt privileged-without-host-devices`: Don't pass host devices to privileged containers
 - :whale: `--cap-add=<CAP>`: Add Linux capabilities
 - :whale: `--cap-drop=<CAP>`: Drop Linux capabilities


### PR DESCRIPTION
This change adds security option to turn off confinement for system paths (masked paths, read-only paths) for the container.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
