### PR TITLE
Add nerdctl build --add-host option support

### DIFF
--- a/cmd/nerdctl/builder/builder_build.go
+++ b/cmd/nerdctl/builder/builder_build.go
@@ -45,6 +45,7 @@ If Dockerfile is not present and -f is not specified, it will look for Container
 		SilenceErrors: true,
 	}
 	helpers.AddStringFlag(buildCommand, "buildkit-host", nil, "", "BUILDKIT_HOST", "BuildKit address")
+	buildCommand.Flags().StringArray("add-host", nil, "Add a custom host-to-IP mapping (format: \"host:ip\")")
 	buildCommand.Flags().StringArrayP("tag", "t", nil, "Name and optionally a tag in the 'name:tag' format")
 	buildCommand.Flags().StringP("file", "f", "", "Name of the Dockerfile")
 	buildCommand.Flags().String("target", "", "Set the target build stage to build")
@@ -89,6 +90,10 @@ func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBu
 		return types.BuilderBuildOptions{}, err
 	}
 	buildKitHost, err := GetBuildkitHost(cmd, globalOptions.Namespace)
+	if err != nil {
+		return types.BuilderBuildOptions{}, err
+	}
+	extraHosts, err := cmd.Flags().GetStringArray("add-host")
 	if err != nil {
 		return types.BuilderBuildOptions{}, err
 	}
@@ -232,6 +237,7 @@ func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBu
 		Stdin:                cmd.InOrStdin(),
 		NetworkMode:          network,
 		ExtendedBuildContext: extendedBuildCtx,
+		ExtraHosts:           extraHosts,
 	}, nil
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -714,8 +714,9 @@ Flags:
 - :whale: `--label`: Set metadata for an image
 - :whale: `--network=(default|host|none)`: Set the networking mode for the RUN instructions during build.(compatible with `buildctl build`)
 - :whale: `--build-context`: Set additional contexts for build (e.g. dir2=/path/to/dir2, myorg/myapp=docker-image://path/to/myorg/myapp)
+- :whale: `--add-host`: Add a custom host-to-IP mapping (format: `host:ip`)
 
-Unimplemented `docker build` flags: `--add-host`, `--squash`
+Unimplemented `docker build` flags: `--squash`
 
 ### :whale: nerdctl commit
 

--- a/pkg/api/types/builder_types.go
+++ b/pkg/api/types/builder_types.go
@@ -71,6 +71,8 @@ type BuilderBuildOptions struct {
 	NetworkMode string
 	// Pull determines if we should try to pull latest image from remote. Default is buildkit's default.
 	Pull *bool
+	// ExtraHosts is a set of custom host-to-IP mappings.
+	ExtraHosts []string
 }
 
 // BuilderPruneOptions specifies options for `nerdctl builder prune`.

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
+	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -451,6 +452,14 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 		default:
 			log.L.Debugf("ignoring network build arg %s", options.NetworkMode)
 		}
+	}
+
+	if len(options.ExtraHosts) > 0 {
+		extraHosts, err := containerutil.ParseExtraHosts(options.ExtraHosts, options.GOptions.HostGatewayIP, "=")
+		if err != nil {
+			return "", nil, false, "", nil, nil, err
+		}
+		buildctlArgs = append(buildctlArgs, "--opt=add-hosts="+strings.Join(extraHosts, ","))
 	}
 
 	return buildctlBinary, buildctlArgs, needsLoading, metaFile, tags, cleanup, nil

--- a/pkg/containerutil/containerutil_test.go
+++ b/pkg/containerutil/containerutil_test.go
@@ -1,0 +1,83 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseExtraHosts(t *testing.T) {
+	tests := []struct {
+		name           string
+		extraHosts     []string
+		hostGateway    string
+		separator      string
+		expected       []string
+		expectedErrStr string
+	}{
+		{
+			name:     "NoExtraHosts",
+			expected: []string{},
+		},
+		{
+			name:       "ExtraHosts",
+			extraHosts: []string{"localhost:127.0.0.1", "localhost:[::1]"},
+			separator:  ":",
+			expected:   []string{"localhost:127.0.0.1", "localhost:[::1]"},
+		},
+		{
+			name:       "EqualsSeperator",
+			extraHosts: []string{"localhost:127.0.0.1", "localhost:[::1]"},
+			separator:  "=",
+			expected:   []string{"localhost=127.0.0.1", "localhost=[::1]"},
+		},
+		{
+			name:           "InvalidExtraHostFormat",
+			extraHosts:     []string{"localhost"},
+			expectedErrStr: "bad format for add-host: \"localhost\"",
+		},
+		{
+			name:           "ErrorOnHostGatewayExtraHostWithNoHostGatewayIPSet",
+			extraHosts:     []string{"localhost:host-gateway"},
+			separator:      ":",
+			expectedErrStr: "unable to derive the IP value for host-gateway",
+		},
+		{
+			name:        "HostGatewayIP",
+			extraHosts:  []string{"localhost:host-gateway"},
+			hostGateway: "10.10.0.1",
+			separator:   ":",
+			expected:    []string{"localhost:10.10.0.1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			extraHosts, err := ParseExtraHosts(test.extraHosts, test.hostGateway, test.separator)
+			if err != nil && err.Error() != test.expectedErrStr {
+				t.Fatalf("expected '%s', actual '%v'", test.expectedErrStr, err)
+			} else if err == nil && test.expectedErrStr != "" {
+				t.Fatalf("expected error '%s' but got none", test.expectedErrStr)
+			}
+
+			if !reflect.DeepEqual(test.expected, extraHosts) {
+				t.Fatalf("expected %v, actual %v", test.expected, extraHosts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change refactors the parse extra hosts logic from container run command and adds support for image build add-host flag.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
