### PR TITLE
Fix image inspect exit code on image not found error

### DIFF
--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -18,6 +18,8 @@ package image
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -60,6 +62,14 @@ func TestImageInspectSimpleCases(t *testing.T) {
 				Description: "typedFormat support (.ID)",
 				Command:     test.Command("image", "inspect", testutil.CommonImage, "--format", "{{.ID}}"),
 				Expected:    test.Expects(0, nil, nil),
+			},
+			{
+				Description: "Error for image not found",
+				Command:     test.Command("image", "inspect", "dne:latest", "dne2:latest"),
+				Expected: test.Expects(1, []error{
+					errors.New("no such image: dne:latest"),
+					errors.New("no such image: dne2:latest"),
+				}, nil),
 			},
 		},
 	}
@@ -171,7 +181,8 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 							for _, id := range []string{"doesnotexist", "doesnotexist:either", "busybox:bogustag"} {
 								cmd := helpers.Command("image", "inspect", id+"@sha256:"+sha)
 								cmd.Run(&test.Expected{
-									Output: test.Equals(""),
+									ExitCode: 1,
+									Errors:   []error{fmt.Errorf("no such image: %s@sha256:%s", id, sha)},
 								})
 							}
 						},
@@ -192,7 +203,8 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 							for _, id := range []string{"∞∞∞∞∞∞∞∞∞∞", "busybox:∞∞∞∞∞∞∞∞∞∞"} {
 								cmd := helpers.Command("image", "inspect", id)
 								cmd.Run(&test.Expected{
-									Output: test.Equals(""),
+									ExitCode: 1,
+									Errors:   []error{fmt.Errorf("invalid reference format: %s", id)},
 								})
 							}
 						},

--- a/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
@@ -175,11 +175,13 @@ func TestIPFSSimple(t *testing.T) {
 				helpers.Ensure("image", "encrypt", "--recipient=jwe:"+keyPair.Pub, data.Get(mainImageCIDKey), data.Identifier("encrypted"))
 				cmd := helpers.Command("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", data.Identifier("encrypted"))
 				cmd.Run(&test.Expected{
-					Output: test.Equals("1\n"),
+					ExitCode: 1,
+					Output:   test.Equals("1\n"),
 				})
 				cmd = helpers.Command("image", "inspect", "--mode=native", "--format={{json (index .Manifest.Layers 0) }}", data.Identifier("encrypted"))
 				cmd.Run(&test.Expected{
-					Output: test.Contains("org.opencontainers.image.enc.keys.jwe"),
+					ExitCode: 1,
+					Output:   test.Contains("org.opencontainers.image.enc.keys.jwe"),
 				})
 
 				// Push the encrypted image and save the CID

--- a/pkg/cmd/image/inspect.go
+++ b/pkg/cmd/image/inspect.go
@@ -97,6 +97,7 @@ func Inspect(ctx context.Context, client *containerd.Client, identifiers []strin
 	defer cancel()
 
 	// Will hold the final answers
+	var errs []string
 	var entries []interface{}
 
 	snapshotter := containerdutil.SnapshotService(client, options.GOptions.Snapshotter)
@@ -104,7 +105,7 @@ func Inspect(ctx context.Context, client *containerd.Client, identifiers []strin
 	for _, identifier := range identifiers {
 		candidateImageList, requestedName, requestedTag, err := inspectIdentifier(ctx, client, identifier)
 		if err != nil {
-			log.G(ctx).WithError(err).WithField("identifier", identifier).Error("failure calling inspect")
+			errs = append(errs, fmt.Sprintf("invalid reference format: %s", identifier))
 			continue
 		}
 
@@ -185,6 +186,8 @@ func Inspect(ctx context.Context, client *containerd.Client, identifiers []strin
 			// Store our image
 			// foundImages[validatedDigest] = validatedImage
 			entries = append(entries, validatedImage)
+		} else {
+			errs = append(errs, fmt.Sprintf("no such image: %s", identifier))
 		}
 	}
 
@@ -193,6 +196,10 @@ func Inspect(ctx context.Context, client *containerd.Client, identifiers []strin
 		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, entries); formatErr != nil {
 			log.G(ctx).Error(formatErr)
 		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%d errors:\n%s", len(errs), strings.Join(errs, "\n"))
 	}
 
 	return nil


### PR DESCRIPTION
This change fixes image inspect command to error when image is not found.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
